### PR TITLE
Remove explicit dependencies/references to Gradle

### DIFF
--- a/configs/dotfiles/.docker/daemon.json
+++ b/configs/dotfiles/.docker/daemon.json
@@ -3,6 +3,5 @@
         "buildkit": true
     },
     "registry-mirrors": [
-        "https://docker.repo.grdev.net"
     ]
 }

--- a/custom-scripts/post-install-3-git-configuration.sh
+++ b/custom-scripts/post-install-3-git-configuration.sh
@@ -20,8 +20,8 @@ case $applyConfiguration in
 
         git config --global user.name "$fullName"
 
-        printf "Gradle email (e.g. jdoe@gradle.com): "
-        email=$(readInput "jdoe@gradle.com")
+        printf "Git email (e.g. jdoe@employer.example.com): "
+        email=$(readInput "jdoe@employer.example.com")
 
         git config --global user.email "$email"
 


### PR DESCRIPTION
This makes the base config more generic and not have anything specific to Gradle associated with it.